### PR TITLE
trap failed authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ Override defaults with flags (CLI) or the `options` object (node).
 
 All [releases](https://github.com/ungoldman/gh-release/releases) of `gh-release` were created with `gh-release`.
 
+## Config location
+
+Platform | Location
+--- | ---
+OS X | `~/Library/Application Support/gh-release/config.json`
+Linux (XDG) | `$XDG_CONFIG_HOME/gh-release/config.json`
+Linux (Legacy) | `~/.config/gh-release/config.json`
+Windows (> Vista) | `%LOCALAPPDATA%/gh-release/config.json`
+Windows (XP, 2000) | `%USERPROFILE%/Local Settings/Application Data/gh-release/config.json`
+
 ## Motivation
 
 There are packages that already do something like this, and they're great, but I want something that does this one thing really well and nothing else, leans heavily on standards in `package.json` and `CHANGELOG.md`, and can work both as a CLI tool and programmatically in node.

--- a/index.js
+++ b/index.js
@@ -104,6 +104,10 @@ function Release (options, callback) {
         return callback(new Error(errorMessage))
       }
 
+      if (body.message === 'Bad credentials') {
+        return callback(new Error('GitHub says password is no beuno. please clear your cache manually. https://github.com/ungoldman/gh-release#config-location'))
+      }
+
       if (options.assets) {
         var assets = options.assets.map(function (asset) {
           return path.join(options.workpath, asset)


### PR DESCRIPTION
about half a dozen times i've found myself in a situation where GitHub rejects the token that is passed when attempting to tag a release.  this PR just traps the problem and points the user in the right direction to clear their existing config file.

i haven't been able to determine the root cause, and i don't know if its likely to occur again now that you've moved to using [`ghauth`](https://www.npmjs.com/package/ghauth) but if i'm not the only one it would be a lot cooler for gh-release to trigger a fresh prompt to allow the user to authenticate.  i just couldn't figure out how to do it.