### PR TITLE
function of config endpoint for Node API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ var options = {
   draft: false,
   prerelease: false,
   repo: 'gh-release',
-  owner: 'ungoldman'
+  owner: 'ungoldman',
+  endpoint: 'https://api.github.com/' //for GitHub enterprise, you should change it to http(s)://hostname/api/v3/
 }
 
 // options can also be just an empty object
@@ -137,6 +138,7 @@ All default values taken from `package.json` unless specified otherwise.
 | `draft` | publish as draft | false |
 | `prerelease` | publish as prerelease | false |
 | `assets` | release assets to upload | false |
+| `endpoint` | the api root of GitHub (value changed only take effect in Node API) | https://api.github.com/ |
 
 Override defaults with flags (CLI) or the `options` object (node).
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ var OPTIONS = {
     'draft',
     'prerelease',
     'workpath',
-    'assets'
+    'assets',
+    'endpoint'
   ]
 }
 
@@ -62,10 +63,15 @@ function Release (options, callback) {
   // err if auth info not provided (token or user/pass)
   if (!getAuth(options)) return callback(new Error('missing auth info'))
 
+  // set api root if options's endpoint is not empty (http(s)://hostname/api/v3/ for github enterprise), detail see https://developer.github.com/v3/enterprise/
+  if (options.endpoint) {
+    API_ROOT = options.endpoint
+  }
+
   // check if commit exists on remote
   var getCommitOptions = extend(getAuth(options), {
     method: 'GET',
-    uri: API_ROOT + format('repos/%s/%s/git/commits/%s', options.owner, options.repo, options.target_commitish)
+    uri: API_ROOT + format('repos/%s/%s/commits/%s', options.owner, options.repo, options.target_commitish)
   })
 
   request(getCommitOptions, function (err, res, body) {


### PR DESCRIPTION
For issue #44 .

Added function of set GitHub endpoint for **Node API**.

I also try to added it for CLI, but my enterprise private GitHub has other authentication if use username-password mode (o-auth mode is ok), the module **ghauth** that you choose is only for username-password, so I abandoned.

