### PR TITLE
add endpoint option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- feature: add support for Github Enterprise (use `endpoint` option) ([#44](https://github.com/ungoldman/gh-release/issues/44))
+
+### Miscellaneous
+
 - site: add scripts for generating a gh-pages site
 
 ## [2.1.0] - 2016-07-01

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ var options = {
   draft: false,
   prerelease: false,
   repo: 'gh-release',
-  owner: 'ungoldman'
+  owner: 'ungoldman',
+  endpoint: 'https://api.github.com/' //for GitHub enterprise, you should change it to http(s)://hostname/api/v3/
 }
 
 // options can also be just an empty object
@@ -137,6 +138,7 @@ All default values taken from `package.json` unless specified otherwise.
 | `draft` | publish as draft | false |
 | `prerelease` | publish as prerelease | false |
 | `assets` | release assets to upload | false |
+| `endpoint` | the api root of GitHub (value changed only take effect in Node API) | https://api.github.com/ |
 
 Override defaults with flags (CLI) or the `options` object (node).
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
   -p, --prerelease        publish as prerelease                [default: false]
   --dry-run               dry run (stops before release step)  [default: false]
   -w, --workpath          path to working directory            [default: "<current working directory>"]
+  -e, --endpoint          GitHub API endpoint URL              [default: "https://api.github.com/"]
   -a, --assets            list of assets to upload to release  [default: false]
   -h, --help              Show help
   -v, --version           Show version number
@@ -138,7 +139,7 @@ All default values taken from `package.json` unless specified otherwise.
 | `draft` | publish as draft | false |
 | `prerelease` | publish as prerelease | false |
 | `assets` | release assets to upload | false |
-| `endpoint` | the api root of GitHub (value changed only take effect in Node API) | https://api.github.com/ |
+| `endpoint` | GitHub API endpoint URL | https://api.github.com/ |
 
 Override defaults with flags (CLI) or the `options` object (node).
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Options:
   -p, --prerelease        publish as prerelease                [default: false]
   --dry-run               dry run (stops before release step)  [default: false]
   -w, --workpath          path to working directory            [default: "<current working directory>"]
-  -e, --endpoint          GitHub API endpoint URL              [default: "https://api.github.com/"]
+  -e, --endpoint          GitHub API endpoint URL              [default: "https://api.github.com"]
   -a, --assets            list of assets to upload to release  [default: false]
   -h, --help              Show help
   -v, --version           Show version number
@@ -100,7 +100,7 @@ var options = {
   prerelease: false,
   repo: 'gh-release',
   owner: 'ungoldman',
-  endpoint: 'https://api.github.com/' //for GitHub enterprise, you should change it to http(s)://hostname/api/v3/
+  endpoint: 'https://api.github.com' // for GitHub enterprise, use http(s)://hostname/api/v3
 }
 
 // options can also be just an empty object
@@ -139,7 +139,7 @@ All default values taken from `package.json` unless specified otherwise.
 | `draft` | publish as draft | false |
 | `prerelease` | publish as prerelease | false |
 | `assets` | release assets to upload | false |
-| `endpoint` | GitHub API endpoint URL | https://api.github.com/ |
+| `endpoint` | GitHub API endpoint URL | https://api.github.com |
 
 Override defaults with flags (CLI) or the `options` object (node).
 

--- a/bin/lib/yargs.js
+++ b/bin/lib/yargs.js
@@ -58,7 +58,7 @@ module.exports = require('yargs')
     'e': {
       alias: 'endpoint',
       type: 'string',
-      default: 'https://api.github.com/',
+      default: 'https://api.github.com',
       describe: 'GitHub API endpoint URL'
     },
     'a': {

--- a/bin/lib/yargs.js
+++ b/bin/lib/yargs.js
@@ -55,6 +55,12 @@ module.exports = require('yargs')
       default: process.cwd(),
       describe: 'path to working directory'
     },
+    'e': {
+      alias: 'endpoint',
+      type: 'string',
+      default: 'https://api.github.com/',
+      describe: 'GitHub API endpoint URL'
+    },
     'a': {
       alias: 'assets',
       type: 'string',

--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ var format = require('util').format
 var path = require('path')
 var ghReleaseAssets = require('gh-release-assets')
 
-var API_ROOT = 'https://api.github.com/'
-
 var OPTIONS = {
   required: [
     'auth',
@@ -20,6 +18,7 @@ var OPTIONS = {
   defaults: {
     'dryRun': false,
     'draft': false,
+    'endpoint': 'https://api.github.com/',
     'prerelease': false,
     'workpath': process.cwd()
   },
@@ -33,10 +32,10 @@ var OPTIONS = {
     'name',
     'dryRun',
     'draft',
+    'endpoint',
     'prerelease',
     'workpath',
-    'assets',
-    'endpoint'
+    'assets'
   ]
 }
 
@@ -63,15 +62,10 @@ function Release (options, callback) {
   // err if auth info not provided (token or user/pass)
   if (!getAuth(options)) return callback(new Error('missing auth info'))
 
-  // set api root if options's endpoint is not empty (http(s)://hostname/api/v3/ for github enterprise), detail see https://developer.github.com/v3/enterprise/
-  if (options.endpoint) {
-    API_ROOT = options.endpoint
-  }
-
   // check if commit exists on remote
   var getCommitOptions = extend(getAuth(options), {
     method: 'GET',
-    uri: API_ROOT + format('repos/%s/%s/commits/%s', options.owner, options.repo, options.target_commitish)
+    uri: format('%s/repos/%s/%s/commits/%s', options.endpoint, options.owner, options.repo, options.target_commitish)
   })
 
   request(getCommitOptions, function (err, res, body) {
@@ -81,7 +75,7 @@ function Release (options, callback) {
     }
 
     var releaseOpts = extend(getAuth(options), {
-      uri: API_ROOT + format('repos/%s/%s/releases', options.owner, options.repo),
+      uri: format('%s/repos/%s/%s/releases', options.endpoint, options.owner, options.repo),
       body: {
         tag_name: options.tag_name,
         target_commitish: options.target_commitish,

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ var OPTIONS = {
     'draft',
     'prerelease',
     'workpath',
-    'assets'
+    'assets',
+    'endpoint'
   ]
 }
 
@@ -62,10 +63,15 @@ function Release (options, callback) {
   // err if auth info not provided (token or user/pass)
   if (!getAuth(options)) return callback(new Error('missing auth info'))
 
+  // set api root if options's endpoint is not empty (http(s)://hostname/api/v3/ for github enterprise), detail see https://developer.github.com/v3/enterprise/
+  if (options.endpoint) {
+    API_ROOT = options.endpoint
+  }
+
   // check if commit exists on remote
   var getCommitOptions = extend(getAuth(options), {
     method: 'GET',
-    uri: API_ROOT + format('repos/%s/%s/git/commits/%s', options.owner, options.repo, options.target_commitish)
+    uri: API_ROOT + format('repos/%s/%s/commits/%s', options.owner, options.repo, options.target_commitish)
   })
 
   request(getCommitOptions, function (err, res, body) {


### PR DESCRIPTION
Adds support for alternate API endpoint (for Github Enterprise support).

Resolves #44.

This will be a minor release.