### PR TITLE
deps(dev): rm live-server, tap-spec, use serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,12 @@
   "devDependencies": {
     "gh-pages": "^3.1.0",
     "git-pull-or-clone": "^2.0.1",
-    "live-server": "^1.1.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
+    "serve": "^13.0.2",
     "sitedown": "^5.0.0",
     "snazzy": "^9.0.0",
     "standard": "^16.0.2",
-    "tap-spec": "^5.0.0",
     "tape": "^5.0.1",
     "tmp": "v0.2.1"
   },
@@ -74,13 +73,13 @@
     "pretest": "standard | snazzy",
     "release": "./bin/cli.js && npm publish",
     "serve": "run-p serve:*",
-    "serve:site": "live-server site",
+    "serve:site": "serve site",
     "serve:watch": "npm run site:html -- -w",
     "site": "run-s site:*",
     "site:clean": "rm -rf site",
     "site:html": "sitedown -b site -l docs/layout.html",
     "site:img": "cp demo.gif site/",
     "start": "npm-run-all site --parallel serve:*",
-    "test": "tape test/*.js | tap-spec"
+    "test": "tape test/*.js"
   }
 }


### PR DESCRIPTION
- removed tap-spec since it's unmaintained and adds a lot of security warnings
- removed live-server for same reason as above
- added serve to dev-deps to replace live-server