### PR TITLE
deps: rm chalk

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,7 +3,6 @@
 const extend = require('deep-extend')
 const fs = require('fs')
 const path = require('path')
-const chalk = require('chalk')
 const ghauth = require('ghauth')
 const inquirer = require('inquirer')
 const ghRelease = require('../')
@@ -158,6 +157,6 @@ function performRelease (options) {
 
 function handleError (err) {
   const msg = err.message || JSON.stringify(err, null, 2)
-  console.log(chalk.red(msg))
+  console.log(msg)
   process.exit(1)
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "@octokit/rest": "^18.0.9",
-    "chalk": "^4.1.0",
     "changelog-parser": "^2.0.0",
     "deep-extend": "^0.6.0",
     "gauge": "^v4.0.3",


### PR DESCRIPTION
The `chalk` module is now ESM-only. Since `gh-release` is not, and we only use it in one place to make a CLI error message red, I think it is better to just remove it as a dep altogether. Seems silly to add a dependency for making a single CLI message red anyway.