### PR TITLE
remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
**tl;dr:**

Removing `.npmrc` file so lock gets generated locally for `npm audit`. `package-lock.json` is already listed in `.gitignore`, so won't show up in version control.

---

## Background

Thousands of years ago, there were no package lock files. Then came yarn, then npm followed suit. Many maintainers explicitly disabled lock files, because they made automated tests in CI environments less likely to catch new bugs introduced by dependencies, and generally added a lot of noise to version control while not being particularly useful for module maintainers.

## Present Day

Now lock files are ubiquitous, as well as being necessary for auditing dependencies for security vulnerabilities.

This repo (and many like it) has a `.npmrc` file that disables generation of the lock file in local development. However, this very often leads to what I can only describe as an intensely annoying circumstance as a maintainer:

```
∴ ~/dev/github/gh-release (main) $ npm i

changed 1 package, and audited 603 packages in 2s

125 packages are looking for funding
  run `npm fund` for details

2 vulnerabilities (1 high, 1 critical)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
∴ ~/dev/github/gh-release (main) $ npm audit fix
npm ERR! code ENOLOCK
npm ERR! audit This command requires an existing lockfile.
npm ERR! audit Try creating one first with: npm i --package-lock-only
npm ERR! audit Original error: loadVirtual requires existing shrinkwrap file

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ng/.npm/_logs/2022-04-14T20_57_17_143Z-debug-0.log
```

Since `package-lock.json` is already ignored by git (via `.gitignore`), I'm switching my actively maintained modules to the pattern of **not checking lock files into version control**, while still **enabling lock files locally for audit and debugging**.

There are, of course, as always, trade-offs. Sometimes we as maintainers will forget to remove and regenerate the lock file to follow up on a bug report, thus retaining an outdated dependency tree compared what happens when an end user installs the module for the first time. This is a terrible sacrifice, and I may never recover.