### PR TITLE
chore: dependabot explicit versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    versioning-strategy: "increase"
+
   # Enable updates to github actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### Description

This PR explicitly sets dependabot's `versioning-strategy` to `increase`, making Dependabot always bump versions in the package.json.

This repo hasn't had any Dependabot PRs opened in over 2 years. I suspect the cause for that is that Dependabot is running in library mode (see [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--)). In library mode Dependabot will sometimes only bump versions in the lockfile (which this repo doesn't have).

The other option is that Dependabot has been disabled in the repo settings - which I can't check because I have no access.

Enabling Dependabot would be beneficial to the project because, among other things, it would automatically patch dependencies with known vulnerabilities.