### PR TITLE
chore: remove unused npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "git-pull-or-clone": "^2.0.2",
-    "npm-run-all": "^4.1.5",
     "snazzy": "^9.0.0",
     "standard": "^17.1.2",
     "tap-arc": "^1.3.2",


### PR DESCRIPTION
### Description

Remove `npm-run-all` because it's not being used (which is great because the library has been abandoned for over 6 years now)